### PR TITLE
Altered plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Show how your plugin is to be used
 steps:
   - label: "💭 Sending Teams Notification"
     plugins:
-      - teams-notification#0.0.1:
+      - teams-notification#1.0.0:
           webhook_url: "<webhook_url>"
           message: "From Buildkite with Love"
 ```
@@ -37,7 +37,7 @@ If you want to change the plugin behaviour:
 steps:
   - label: "💭 Sending Teams Notification"
     plugins:
-      - teams-notification#0.0.1:
+      - teams-notification#1.0.0:
           webhook_url: "<webhook_url>"
           message: "From Buildkite with Love" 
 ```

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: Teams Notification
-description: A Buildkite plugin that allows sending incoming webhooks at the pre-exit job lifecycle event.
+description: A Buildkite plugin for sending incoming webhook notifications setup on specific MS Teams channels.
 author: https://github.com/buildkite-plugins
 requirements:
   - bash


### PR DESCRIPTION
`plugin.yml` didn't mention anything about _notifications_ sent by incoming webhooks - though it was correct on using the latter at least.

Small tweak to mention the plugin sends incoming webhook notifications to MS Teams channels